### PR TITLE
bugfix: fail interval was not dumped properly

### DIFF
--- a/timon/config.py
+++ b/timon/config.py
@@ -107,6 +107,7 @@ class TMonConfig(object):
                 name,
                 t_next=t_next,
                 interval=interval,
+                failinterval=failinterval,
                 schedule=schedule,
                 )
 


### PR DESCRIPTION
the fail delay of a probe was lost in the timon state, as it was not passed down properly