### PR TITLE
have now --pdb and --pdb-hook switch

### DIFF
--- a/timon/commands.py
+++ b/timon/commands.py
@@ -82,6 +82,10 @@ def mk_parser():
         action='store_true', help="enable debugging")
     parser.add_argument(
         "--pdb", action="store_true",
+        help="if set pdb will be started at startup",
+        )
+    parser.add_argument(
+        "--pdb-hook", action="store_true",
         help="if set pdb will be started on exceptions",
         )
 
@@ -172,9 +176,13 @@ def main():
         sys.exit(0)
 
     if func:
-        if options.pdb:
+        if options.pdb_hook:
             import mytb.debug
             sys.excepthook = mytb.debug.pdb_debug_hook
+        if options.pdb:
+            # TODO: replace next 2 lines with breakpoint() for PY >= 3.7
+            import pdb
+            pdb.set_trace()
         if not type(func) is str:
             func(options)
         else:


### PR DESCRIPTION
#43 added the option to enter pdb on exceptions.

This PR: changes uses the `--pdb`  option to enter pdb during startup and adds `--pdb-hook` to enable the pdb hook for exceptions.

