### PR TITLE
first shot at github actions setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,32 @@
+name: Timon CI
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 0 * * 0" # weekly
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.6", "3.7", "3.8", "pypy-3.6", "pypy-3.7"]
+    steps:
+        - uses: actions/checkout@v2
+        - name: setup python
+          uses: actions/setup-python@v2
+          with:
+            python-version: ${{ matrix.python-version }}
+            architecture: x64
+        - name: install dependencies
+          run: |
+            python -m pip install -U pip
+            python -m pip install flake8 tox
+        - name: flake
+          run: |
+            python -m flake8 timon setup.py --exclude timon/webclient
+            python -m pip install -r requirements/tox.txt
+        - name: pytest
+          run: pytest
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
         - name: install dependencies
           run: |
             python -m pip install -U pip
-            python -m pip install flake8 tox
+            python -m pip install flake8
         - name: flake
           run: |
             python -m flake8 timon setup.py --exclude timon/webclient


### PR DESCRIPTION
Travis seems to be a little out of fashion and no more recommended.

Thus here a small first shot at using gitlab actions for performing CI.

At the moment travis and github are both performing CI.

If this works nicely the travis runners should be removed.

What is interesting though is, that at the moment Travis seems to run faster than github actions