### PR TITLE
add CI step for isort check. no CI flake for pypy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,10 +23,18 @@ jobs:
           run: |
             python -m pip install -U pip
             python -m pip install flake8
+        - name: check import order
+          if: ${{ matrix.python-version == '3.8' }}
+          run: |
+            python -m pip install isort
+            python -m isort --show-files setup.py timon
+            python -m isort --diff --check setup.py timon
         - name: flake
+          if: ${{ matrix.python-version < 'pypy' }}
           run: |
             python -m flake8 timon setup.py --exclude timon/webclient
-            python -m pip install -r requirements/tox.txt
         - name: pytest
-          run: pytest
+          run: |
+            python -m pip install -r requirements/tox.txt
+            pytest
 


### PR DESCRIPTION
- add an isort CI step for py3.8
- perform flake CI step only for py 3.6, 3.7, 3.8 (skip for pypy as
     pypy flake should not yield different results than 3.6 or 3.7)