### PR TITLE
Dvl/feenes/fix scheduler

### DIFF
--- a/TESTING.rst
+++ b/TESTING.rst
@@ -22,10 +22,10 @@ Now test for shell loop::
     python -m timon.tst_helpers.comp_results expected_seq.csv tst_probe.shell.csv
 
 
-Now test for default loop (This fails at the moment to be investigated)::
+Now test for default loop (This fails at the moment. To be investigated ...)::
 
-    rm -f t0.txt tst_probe.csv timon_state.json && timon --pdb-hook run -s -d 0.3
+    rm -f t0.txt tst_probe.csv timon_state.json && timon --pdb-hook run -l -d 0.3
     # let script run for about a minute and press CTRL-C
-    cp tst_probe.csv tst_probe.shell.csv
+    cp tst_probe.csv tst_probe.loop.csv
     python -m timon.tst_helpers.comp_results expected_seq.csv tst_probe.loop.csv
 

--- a/TESTING.rst
+++ b/TESTING.rst
@@ -22,7 +22,7 @@ Now test for shell loop::
     python -m timon.tst_helpers.comp_results expected_seq.csv tst_probe.shell.csv
 
 
-Now test for default loop (This fails at the moment. To be investigated ...)::
+Now test for default loop::
 
     rm -f t0.txt tst_probe.csv timon_state.json && timon --pdb-hook run -l -d 0.3
     # let script run for about a minute and press CTRL-C

--- a/timon/commands.py
+++ b/timon/commands.py
@@ -133,7 +133,6 @@ def mk_parser():
     sub_prs.add_argument(
             '-d', '--loop-delay', default="auto",
             help="specifies loop delay")
-
     sub_prs.add_argument(
             '--statefile',
             help=('specific location for a state file'

--- a/timon/run.py
+++ b/timon/run.py
@@ -114,7 +114,7 @@ async def run_once(options, loop=None, first=False, cfg=None):
     cfg.save_state()
 
     t = time.time()
-    t_delta_next = max(t_next - t, 1)
+    t_delta_next = max(t_next - t, 0)
 
     if runner.notifier_objs:
         for notifier in runner.notifier_objs:
@@ -125,7 +125,7 @@ async def run_once(options, loop=None, first=False, cfg=None):
     if not loop:
         runner.close()
 
-    return max(t_next - t, 1), None, []
+    return max(t_next - t, 0), None, []
 
 
 async def run_loop(options, cfg, run_once_func=run_once, t00=None):

--- a/timon/runner.py
+++ b/timon/runner.py
@@ -72,7 +72,7 @@ class Runner:
         """
         call back to be executed when probe execution is finished
         """
-        print("DONE: ", probe, status)
+        logger.debug("DONE: %s %s", str(probe), status)
         queue = self.queue
         cfg = self.cfg
         now = time.time()

--- a/timon/state.py
+++ b/timon/state.py
@@ -78,11 +78,13 @@ class TMonQueue(object):
         heap = self.heap
         pop = self.pop
         all_probes = self.probes
+        logger.debug("get_probes (%d to examine)", len(heap))
         while True:
             if not heap or ((heap[0][0] > now) and not force):
                 if heap:
-                    print("H0 %r > %r (delta: %.0f) aborting" % (heap[0],
-                          now, heap[0][0] - now))
+                    logger.debug("H0 %s > %s (delta: %.1f). aborting",
+                        str(heap[0]),
+                          now, heap[0][0] - now)
                 break
             _t, entry = pop()
             entry = dict(entry)
@@ -96,6 +98,7 @@ class TMonQueue(object):
             entry.update(probe_args)
             cls_name = probe_args['cls']
             probe = mk_probe(cls_name, **entry)
+            logger.debug("will yield %s", str(probe))
             yield probe
 
     def __repr__(self):

--- a/timon/state.py
+++ b/timon/state.py
@@ -82,9 +82,9 @@ class TMonQueue(object):
         while True:
             if not heap or ((heap[0][0] > now) and not force):
                 if heap:
-                    logger.debug("H0 %s > %s (delta: %.1f). aborting",
-                        str(heap[0]),
-                          now, heap[0][0] - now)
+                    logger.debug(
+                        "H0 %s > %s (delta: %.1f). aborting",
+                        str(heap[0]), now, heap[0][0] - now)
                 break
             _t, entry = pop()
             entry = dict(entry)

--- a/timon/tst_helpers/comp_results.py
+++ b/timon/tst_helpers/comp_results.py
@@ -42,13 +42,13 @@ def compare_filtered(name, reference, results):
         expval = expected["status"]
         gotval = got["status"]
         if expval != gotval:
-            print(f"Value mismatch at {idx}: {expected} != {got}")
+            print(f"Value mismatch at line {idx}: {expected} != {got}")
         exp_t = float(expected["t"])
         got_t = float(got["t"])
         delta_t = abs(exp_t - got_t)
         if delta_t > 0.5:
             print(
-                f"Time mismatch at {idx}: |{exp_t} - {got_t}|"
+                f"Time mismatch at line {idx}: |{exp_t} - {got_t}|"
                 f" = {delta_t} (> 0.5)")
     return count
 


### PR DESCRIPTION
this fix allows that scheduler tests with short delays don't detect deltas / errors

scheduler will no more force a minimum delay of 1s between run_once calls.

The fix can be found in commit 8679c4ec035b1425f4d4df2dd2f141cf22b03f30

further:
- some print()s have been converted to log commands
- corrected some errors in testing documentation