### PR TITLE
don't fail if hprobes is None

### DIFF
--- a/timon/configure.py
+++ b/timon/configure.py
@@ -146,6 +146,9 @@ def complete_hosts(cfg):
                          host['name'], host['probes'])
 
         hprobes = host['probes']
+        if hprobes is None:
+            logger.debug("hprobes is None")
+            hprobes = []
 
         if type(hprobes) in (str,):  # if only one probe conv to list of one
             hprobes = [hprobes]


### PR DESCRIPTION
if yaml config files are created the 'wrong' way it may happen, that a None object is created instead of an empty list.
Code has been robustified to handle this case.