### PR TITLE
FIX probes in heap disappears+ Cleanup (print to logs)

### DIFF
--- a/timon/notifiers/base.py
+++ b/timon/notifiers/base.py
@@ -13,7 +13,7 @@ class Notifier:
         global logger
         kwargs.pop('cls', None)  # get rid of cls
         logger = logger if logger else logging.getLogger(__name__)
-        print("CREATE A NOTIFIER")
+        logger.debug("CREATE A NOTIFIER")
         notify_states = ["WARNING", "ERROR"]
         notify_states = list(kwargs.pop('notify_states', [])) or notify_states
         self.name = kwargs.pop('name', None)
@@ -33,7 +33,9 @@ class Notifier:
 
     async def notify(self, probe=None, probe_state=None):
         status = probe_state[-1][1]
-        print("#### NOTIFY ####", probe.name, status, self.users)
+        logger.info(
+            "#### NOTIFY #### name:%s , status=%s, users=%r",
+            probe.name, status, self.users)
 
 
 def get_notifier_cls(cls_name):

--- a/timon/probes/probes.py
+++ b/timon/probes/probes.py
@@ -83,9 +83,9 @@ class Probe:
             raise
         finally:
             if rsrc:
-                print("RLS RSRC", rsrc)
+                logger.debug("RLS RSRC %r", rsrc)
                 rsrc.semaph.release()
-                print("RLSD RSRC", rsrc)
+                logger.debug("RLSD RSRC %r", rsrc)
         if self.done_cb:
             await self.done_cb(self, status=self.status, msg=self.msg)
 
@@ -131,12 +131,12 @@ class SubProcBprobe(Probe):
                 entry = entry()
             final_cmd.append(entry)
         logger.info("shall call %s", ' '.join(cmd))
-        print(" ".join(final_cmd))
+        logger.debug(" ".join(final_cmd))
         return final_cmd
 
     async def probe_action(self):
         final_cmd = self.create_final_command()
-        print(" ".join(final_cmd))
+        logger.debug(" ".join(final_cmd))
         self.process = await trio.run_process(
             final_cmd,
             stderr=subprocess.STDOUT,
@@ -270,7 +270,7 @@ class HttpProbe(Probe):
 
 class ThreadProbe(Probe):
     async def probe_action(self):
-        print("THREAD")
+        logger.debug("THREAD")
         await trio.sleep(random.random()*1)
 
 

--- a/timon/probes/probes.py
+++ b/timon/probes/probes.py
@@ -83,7 +83,6 @@ class Probe:
             raise
         finally:
             if rsrc:
-                logger.debug("RLS RSRC %r", rsrc)
                 rsrc.semaph.release()
                 logger.debug("RLSD RSRC %r", rsrc)
         if self.done_cb:
@@ -270,7 +269,6 @@ class HttpProbe(Probe):
 
 class ThreadProbe(Probe):
     async def probe_action(self):
-        logger.debug("THREAD")
         await trio.sleep(random.random()*1)
 
 

--- a/timon/resources.py
+++ b/timon/resources.py
@@ -65,7 +65,7 @@ async def acquire_rsrc(cls):
     """ acquires resource of a timon class if existing """
     rsrc = get_resource(cls)
     if rsrc:
-        print("GET RSRC", cls.resources)
+        logger.debug("GET RSRC %r", cls.resources)
         await rsrc.semaph.acquire()
-        print("GOT RSRC", cls.resources)
+        logger.debug("GOT RSRC %r", cls.resources)
         return rsrc

--- a/timon/run.py
+++ b/timon/run.py
@@ -32,7 +32,7 @@ async def ask_exit(loop, signame):
     This code is an attempt to help performing a
     clean shutdown
     """
-    print("got signal %s: will exit" % signame)
+    logger.info("got signal %r: will exit", signame)
     await trio.sleep(1.0)
     loop.stop()
 
@@ -73,7 +73,7 @@ async def run_once(options, first=False, cfg=None):
             t_next: in how many seconds the next probe should be fired
             notifiers: list of notifiers, that were started
     """
-    logger.debug("Start run once with options=%r", options)
+    logger.info("Start run once with options=%r", options)
     t0 = time.time()  # now
     # logger.debug("OPTS:%s", str(options))
     cfg = cfg if cfg else get_config(options=options)
@@ -87,7 +87,6 @@ async def run_once(options, first=False, cfg=None):
         logger.debug("IR")
 
         # get all queue entries less than a certain time stamp (dflt=now)
-
     if options.probe:
         to_call = set(options.probe)
         probes = []
@@ -137,7 +136,7 @@ async def run_loop(options, cfg, run_once_func=run_once, t00=None):
     paranoia_loop = options.paranoia_loop
     paranoia_time_break = False
     if paranoia_loop:
-        print("RUNMODE PARANO")
+        logger.info("RUNMODE PARANO")
         start_time = time.time()
         end_planned_time = start_time + PARANOIA_LOOP_BREAK_INTERVAL
     logger.debug(
@@ -178,7 +177,7 @@ async def run_loop(options, cfg, run_once_func=run_once, t00=None):
                 nursery.start_soon(notifier)
                 logger.debug("notifier done")
     if paranoia_loop and paranoia_time_break:
-        print("PARANO END LOOP will start another subproc")
+        logger.info("PARANO END LOOP will start another subproc")
         os.execl(sys.argv[0], *sys.argv)
     return dly, notifiers
 

--- a/timon/runner.py
+++ b/timon/runner.py
@@ -70,7 +70,7 @@ class Runner:
         """
         probe_tasks = []
         probes = list(probes)  # for debugging
-        print("%d probes to run" % len(probes))
+        logger.info("%d probes to run", len(probes))
         for probe in probes:
             probe.done_cb = self.probe_done
             probe_tasks.append(probe.run)
@@ -79,7 +79,7 @@ class Runner:
                 nursery.start_soon(task)
         t = time.time()
         delta_t = t - t0
-        print("Execution time %.1f" % delta_t)
+        logger.info("Execution time %d", delta_t)
         return t
 
     async def probe_done(self, probe, status=None, msg="?"):
@@ -98,15 +98,14 @@ class Runner:
         probe_state = state.get_probe_state(probe)
 
         if status_has_changed:
-            print("Status changed to %s." % status)
+            logger.debug("Status changed to %s.", status)
             for notifier_name in probe.notifiers:
-                print("check notifier", notifier_name)
+                logger.info("check notifier %r", notifier_name)
                 notifier = cfg.get_notifier(notifier_name)
                 if notifier.shall_notify(probe, probe_state):
                     notifier.add_probe_info(probe, probe_state)
                     if notifier not in self.notifier_objs:
                         self.notifier_objs.append(notifier)
-
         if queue:
             # reschedule depending on status
             if status in ["OK", "UNKNOWN"]:
@@ -125,7 +124,7 @@ class Runner:
 
 def main():
     """ very basic main function to show case running of probes """
-    print("runner")
+    logger.debug("runner")
     urls = [
         "https://www.github.com",
         "https://www.google.com",

--- a/timon/runner.py
+++ b/timon/runner.py
@@ -106,7 +106,7 @@ class Runner:
                     notifier.add_probe_info(probe, probe_state)
                     if notifier not in self.notifier_objs:
                         self.notifier_objs.append(notifier)
-        if queue:
+        if queue is not None:
             # reschedule depending on status
             if status in ["OK", "UNKNOWN"]:
                 t_next = max(now, probe.t_next + probe.interval)

--- a/timon/scripts/cert_check.py
+++ b/timon/scripts/cert_check.py
@@ -13,6 +13,7 @@ Summary      : probe to check cert validity
 """
 # #############################################################################
 import datetime
+import logging
 import ssl
 import sys
 
@@ -25,6 +26,8 @@ from timon.conf.flags import FLAG_ERROR_STR
 from timon.conf.flags import FLAG_MAP
 from timon.conf.flags import FLAG_OK_STR
 from timon.conf.flags import FLAG_WARNING_STR
+
+logger = logging.getLogger(__name__)
 
 helptxt = ("""
 checks validity of ssl cert for a given server
@@ -89,8 +92,8 @@ def main(hostport, servername=None):
     servername = hostname if not servername else servername
 
     if (servername != hostname):
-        print(
-            "%s: servername param still not fully supported" % FLAG_ERROR_STR)
+        logger.warning(
+            "%s: servername param still not fully supported", FLAG_ERROR_STR)
         exit(FLAG_ERROR)
 
     try:

--- a/timon/scripts/clientca_check.py
+++ b/timon/scripts/clientca_check.py
@@ -12,6 +12,7 @@ Summary: probe to check whether an ssl server accepts certs signed by a
         given CA
 """
 # #############################################################################
+import logging
 import re
 import socket
 import sys
@@ -23,6 +24,8 @@ from timon.conf.flags import FLAG_ERROR_STR
 from timon.conf.flags import FLAG_MAP
 from timon.conf.flags import FLAG_OK_STR
 from timon.conf.flags import FLAG_UNKNOWN_STR
+
+logger = logging.getLogger(__name__)
 
 helptxt = ("""
 checks whether client certs signed by a given CA will be accepted by a server

--- a/timon/state.py
+++ b/timon/state.py
@@ -92,8 +92,7 @@ class TMonQueue(object):
             probe_args = all_probes.get(entry_name)
             if probe_args is None:
                 msg = "Probe %r not found. It might be obsolete" % entry_name
-                print("WARNING:", msg)
-                logger.warning(msg)
+                logger.warning("WARNING: %r", msg)
                 continue
             entry.update(probe_args)
             cls_name = probe_args['cls']
@@ -207,7 +206,7 @@ class TMonState(object):
         except FileNotFoundError:
             pass
         for entry in entries:
-            print(entry)
+            logger.debug(entry)
         if entries:
             1/0
 

--- a/timon/state.py
+++ b/timon/state.py
@@ -92,7 +92,7 @@ class TMonQueue(object):
             probe_args = all_probes.get(entry_name)
             if probe_args is None:
                 msg = "Probe %r not found. It might be obsolete" % entry_name
-                logger.warning(msg)
+                logger.warning("%s", msg)
                 continue
             entry.update(probe_args)
             cls_name = probe_args['cls']

--- a/timon/state.py
+++ b/timon/state.py
@@ -92,7 +92,7 @@ class TMonQueue(object):
             probe_args = all_probes.get(entry_name)
             if probe_args is None:
                 msg = "Probe %r not found. It might be obsolete" % entry_name
-                logger.warning("WARNING: %r", msg)
+                logger.warning(msg)
                 continue
             entry.update(probe_args)
             cls_name = probe_args['cls']


### PR DESCRIPTION
Change some prints to logs to permits a more cumfortable log reading

FIX: in loop mode, after the first run, probes never called again. The problem is that it seems python change the way to check if an object is True or False, and it now considers the queue was False if it's len property was 0.